### PR TITLE
Fixed argument name in example

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -43,7 +43,7 @@ PyBioNetGen's library can also be used to run a BNGL model
 .. code-block:: shell
 
    import bionetgen
-   result = bionetgen.run("mymodel.bngl", output="myfolder")
+   result = bionetgen.run("mymodel.bngl", out="myfolder")
 
 which will create numpy record arrays.
 For other methods or more information on how to use PyBioNetGen's library, please see :ref:`library`.


### PR DESCRIPTION
The `output` argument throws a _TypeError: run() got an unexpected keyword argument 'output'_.
The Library's documentation uses `out` instead, which works fine.