### PR TITLE
Fixes to several github issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
       shell: bash
     - name: Build
       run: |
-        python setup.py install
-        python setup.py sdist bdist_wheel
+        python -m pip install --upgrade pip
+        python -m pip install .
     - name: Test with PyTest
       run: |
         pytest

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,0 +1,35 @@
+name: release-test
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  test-release:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install bionetgen from PyPI
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install bionetgen
+
+      - name: Smoke test bionetgen command
+        run: |
+          bionetgen -h
+          python -c "import bionetgen; print('bionetgen', bionetgen.__version__)"
+
+      - name: Run unit tests
+        run: |
+          python -m pip install pytest
+          pytest

--- a/bionetgen/__main__.py
+++ b/bionetgen/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/bionetgen/core/tools/info.py
+++ b/bionetgen/core/tools/info.py
@@ -64,6 +64,50 @@ class BNGInfo:
         # Save version info
         self.info["Perl version"] = text[num_start:num_end] + " (used to run BNG2.pl)"
 
+        # Get NFsim version (if available on PATH or adjacent to BNG2.pl)
+        self.logger.debug("NFsim info", loc=f"{__file__} : BNGInfo.gatherInfo()")
+        nf_version_text = "not found"
+        try:
+            # Try the standard PATH lookup first
+            result = subprocess.run(
+                ["NFsim", "--version"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                nf_version_text = result.stdout.strip().splitlines()[0]
+            else:
+                nf_version_text = f"exit {result.returncode}"
+        except FileNotFoundError:
+            # If NFsim isn't on PATH, attempt to locate it relative to BNG2.pl
+            try:
+                bng2_path = self.config.get("bionetgen", "bngpath")
+                bng2_dir = os.path.dirname(bng2_path)
+                candidates = [
+                    os.path.join(bng2_dir, "bin", "NFsim"),
+                    os.path.join(bng2_dir, "bin", "NFsim.exe"),
+                ]
+                for cmd in candidates:
+                    if os.path.isfile(cmd):
+                        result = subprocess.run(
+                            [cmd, "--version"],
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            text=True,
+                            timeout=10,
+                        )
+                        if result.returncode == 0:
+                            nf_version_text = result.stdout.strip().splitlines()[0]
+                            break
+            except Exception:
+                pass
+        except Exception as e:
+            nf_version_text = f"error: {e}"
+
+        self.info["NFsim version"] = nf_version_text
+
         self.logger.debug("PyBNG info", loc=f"{__file__} : BNGInfo.gatherInfo()")
         # Get CLI version
         with open(

--- a/bionetgen/core/utils/utils.py
+++ b/bionetgen/core/utils/utils.py
@@ -1,6 +1,7 @@
-import os, subprocess
+import os
+import shutil
+import subprocess
 from bionetgen.core.exc import BNGPerlError
-from distutils import spawn
 
 from bionetgen.core.utils.logging import BNGLogger
 
@@ -589,7 +590,7 @@ def find_BNG_path(BNGPATH=None):
             return hit
 
     # 3) On PATH
-    bng_on_path = spawn.find_executable("BNG2.pl")
+    bng_on_path = shutil.which("BNG2.pl")
     if bng_on_path:
         tried.append(bng_on_path)
         hit = _try_path(bng_on_path)
@@ -616,7 +617,7 @@ def test_perl(app=None, perl_path=None):
     logger.debug("Checking if perl is installed.", loc=f"{__file__} : test_perl()")
     # find path to perl binary
     if perl_path is None:
-        perl_path = spawn.find_executable("perl")
+        perl_path = shutil.which("perl")
     if perl_path is None:
         raise BNGPerlError
     # check if perl is actually working

--- a/bionetgen/modelapi/xmlparsers.py
+++ b/bionetgen/modelapi/xmlparsers.py
@@ -702,10 +702,11 @@ class RuleBlockXML(XMLObj):
             del_op = list_ops["Delete"]
             if not isinstance(del_op, list):
                 del_op = [del_op]  # Make sure del_op is list
-            dmvals = [op["@DeleteMolecules"] for op in del_op]
-            # All Delete operations in rule must have DeleteMolecules attribute or
-            # it does not apply to the whole rule
-            if all(dmvals) == 1:
+
+            # Use get() to avoid KeyError if the attribute is missing.
+            dmvals = [op.get("@DeleteMolecules") for op in del_op]
+            # All Delete operations in rule must have DeleteMolecules attribute set to "1".
+            if all(dmvals) and all(str(v) == "1" for v in dmvals):
                 rule_mod.type = "DeleteMolecules"
                 # JRF: I don't believe the id of the specific op rule_mod is currently used
                 # rule_mod.id = op["@id"]
@@ -731,21 +732,22 @@ class RuleBlockXML(XMLObj):
                 for mo in move_op:
                     if mo["@moveConnected"] == "1":
                         rule_mod.type = "MoveConnected"
-                        rule_mod.id.append(move_op["@id"])
-                        rule_mod.source.append(move_op["@source"])
-                        rule_mod.destination.append(move_op["@destination"])
-                        rule_mod.flip.append(move_op["@flipOrientation"])
+                        rule_mod.id.append(mo["@id"])
+                        rule_mod.source.append(mo["@source"])
+                        rule_mod.destination.append(mo["@destination"])
+                        rule_mod.flip.append(mo["@flipOrientation"])
                         rule_mod.call.append(mo["@moveConnected"])
         elif "RateLaw" in xml:
             # check if modifier is called
             ratelaw = xml["RateLaw"]
             rate_type = ratelaw["@type"]
-            if rate_type == "Function" and ratelaw["@totalrate"] == 1:
+            # @totalrate comes as a string in the XML
+            if rate_type == "Function" and str(ratelaw.get("@totalrate")) == "1":
                 rule_mod.type = "TotalRate"
                 rule_mod.id = ratelaw["@id"]
                 rule_mod.rate_type = ratelaw["@type"]
                 rule_mod.name = ratelaw["@name"]
-                rule_mod.call = ratelaw["@totalrate"]
+                rule_mod.call = ratelaw.get("@totalrate")
 
         # TODO: add support for include/exclude reactants/products
         if (

--- a/bionetgen/simulator/csimulator.py
+++ b/bionetgen/simulator/csimulator.py
@@ -1,7 +1,13 @@
 import ctypes, os, tempfile, bionetgen
 import numpy as np
 
-from distutils import ccompiler
+# distutils is deprecated in Python 3.12+. setuptools still provides the
+# equivalent via setuptools._distutils for backwards compatibility.
+try:
+    from setuptools._distutils import ccompiler
+except ImportError:
+    from distutils import ccompiler
+
 from .bngsimulator import BNGSimulator
 from bionetgen.main import BioNetGen
 from bionetgen.core.exc import BNGCompileError

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,9 @@ def get_folder(arch):
     return fname
 
 
-subprocess.check_call([sys.executable, "-m", "pip", "install", "numpy"])
+# Note: don't run pip install at import time; in PEP 517 builds pip isn't available
+# and running subprocesses during import breaks isolated build environments.
+# numpy is declared in install_requires and will be installed by pip.
 import urllib.request
 import itertools as itt
 

--- a/setup.py
+++ b/setup.py
@@ -186,6 +186,7 @@ setup(
         [console_scripts]
         bionetgen = bionetgen.main:main
     """,
+    python_requires=">=3.8",
     install_requires=[
         "cement",
         "nbopen",
@@ -201,6 +202,9 @@ setup(
         "python-libsbml",
         "pylru",
         "pyparsing",
+        "pyyed",
+        "matplotlib",
+        "pandas",
         "packaging",
     ],
 )

--- a/tests/test_action_parsing.py
+++ b/tests/test_action_parsing.py
@@ -1,0 +1,16 @@
+import pytest
+
+from bionetgen.core.utils.utils import ActionList
+
+
+def test_action_parser_rejects_unclosed_brace():
+    """Ensure malformed actions (missing closing brace) raise a parsing error."""
+
+    alist = ActionList()
+    alist.define_parser()
+
+    # Missing closing '}' should cause pyparsing to raise an exception
+    malformed = "simulate_ssa({t_start=>0,t_end=>10"  # missing closing '}' and ')'
+
+    with pytest.raises(Exception):
+        alist.action_parser.parseString(malformed)

--- a/tests/test_rule_modifiers.py
+++ b/tests/test_rule_modifiers.py
@@ -1,0 +1,79 @@
+import pytest
+
+from bionetgen.modelapi.xmlparsers import RuleBlockXML
+
+
+def _rule_block_parser():
+    # Create a RuleBlockXML instance without running __init__ (which expects full rule XML)
+    return RuleBlockXML.__new__(RuleBlockXML)
+
+
+def test_get_rule_mod_total_rate_string_true():
+    xml = {
+        "ListOfOperations": {},
+        "RateLaw": {"@type": "Function", "@totalrate": "1", "@id": "r1", "@name": "foo"},
+    }
+
+    mod = _rule_block_parser().get_rule_mod(xml)
+    assert mod.type == "TotalRate"
+    assert mod.id == "r1"
+    assert mod.call == "1"
+
+
+def test_get_rule_mod_delete_molecules_all_operations():
+    xml = {
+        "ListOfOperations": {
+            "Delete": [
+                {"@DeleteMolecules": "1"},
+                {"@DeleteMolecules": "1"},
+            ]
+        }
+    }
+
+    mod = _rule_block_parser().get_rule_mod(xml)
+    assert mod.type == "DeleteMolecules"
+
+
+def test_get_rule_mod_delete_molecules_missing_attribute_does_not_apply():
+    xml = {
+        "ListOfOperations": {
+            "Delete": [
+                {"@DeleteMolecules": "1"},
+                {},
+            ]
+        }
+    }
+
+    mod = _rule_block_parser().get_rule_mod(xml)
+    assert mod.type is None
+
+
+def test_get_rule_mod_move_connected_list_uses_each_element():
+    xml = {
+        "ListOfOperations": {
+            "ChangeCompartment": [
+                {
+                    "@moveConnected": "1",
+                    "@id": "a",
+                    "@source": "s",
+                    "@destination": "d",
+                    "@flipOrientation": "0",
+                },
+                {
+                    "@moveConnected": "1",
+                    "@id": "b",
+                    "@source": "s2",
+                    "@destination": "d2",
+                    "@flipOrientation": "1",
+                },
+            ]
+        }
+    }
+
+    mod = _rule_block_parser().get_rule_mod(xml)
+    assert mod.type == "MoveConnected"
+    assert mod.id == ["a", "b"]
+    assert mod.source == ["s", "s2"]
+    assert mod.destination == ["d", "d2"]
+    assert mod.flip == ["0", "1"]
+    assert mod.call == ["1", "1"]

--- a/tests/test_rule_modifiers.py
+++ b/tests/test_rule_modifiers.py
@@ -11,7 +11,12 @@ def _rule_block_parser():
 def test_get_rule_mod_total_rate_string_true():
     xml = {
         "ListOfOperations": {},
-        "RateLaw": {"@type": "Function", "@totalrate": "1", "@id": "r1", "@name": "foo"},
+        "RateLaw": {
+            "@type": "Function",
+            "@totalrate": "1",
+            "@id": "r1",
+            "@name": "foo",
+        },
     }
 
     mod = _rule_block_parser().get_rule_mod(xml)


### PR DESCRIPTION
## Summary

This PR addresses a cluster of bugs and long-standing CI/packaging issues, primarily around Python 3.12 compatibility, broken rule modifier parsing, and the lack of automated release testing.

---

## Changes

### Bug fixes

**`bionetgen/modelapi/xmlparsers.py`** — closes #55

Three bugs in `get_rule_mod()`:

| Bug | Root cause | Fix |
|-----|-----------|-----|
| `TotalRate` never applied | `ratelaw["@totalrate"] == 1` compared string to int, always `False` | `str(ratelaw.get("@totalrate")) == "1"` |
| `DeleteMolecules` `KeyError` | Direct key access crashed if attribute absent on any delete op | `op.get("@DeleteMolecules")` + stricter `all()` check |
| `MoveConnected` wrong ids | Loop variable `mo` never used — all appends read from the outer list `move_op` | `mo["@id"]`, `mo["@source"]`, etc. across all 4 lines |

### Python 3.12 compatibility — closes #58, #61

- `distutils.spawn.find_executable` → `shutil.which` in `utils.py`
- `distutils.ccompiler` → `setuptools._distutils.ccompiler` (with `distutils` fallback) in `csimulator.py`
- `ci.yml`: replaced `python setup.py install && python setup.py sdist bdist_wheel` with `python -m pip install .` (eliminates double BNG binary download and deprecation warnings)
- `setup.py`: added `python_requires=">=3.8"` and promoted `pyyed`, `matplotlib`, `pandas` into `install_requires`

### NFsim version reporting — closes #57

`BNGInfo.gatherInfo()` now detects the NFsim binary and reports its version under `NFsim version`. Lookup order: PATH first, then `bin/` adjacent to BNG2.pl. Gracefully falls back to `"not found"` if unavailable.

### Automated PyPI release testing — closes #60

Adds `.github/workflows/release-test.yml`, triggered on every published release. Installs `bionetgen` from PyPI, runs a smoke test (`bionetgen -h`, `import bionetgen`), then the full pytest suite across Ubuntu / Windows / macOS × Python 3.9–3.12.

### Action exception tests — closes #21

Adds `tests/test_action_parsing.py` with a test confirming pyparsing raises on malformed actions (e.g. missing closing braces).

### Other

- Adds `bionetgen/__main__.py` so `python -m bionetgen` works as an invocation path
- Adds `tests/test_rule_modifiers.py` with full unit test coverage of all three `get_rule_mod()` bug fixes

---

## Issues closed

Closes #21
Closes #55
Closes #57
Closes #58
Closes #60
Closes #61

---

## Testing

- All new tests pass locally
- `test_rule_modifiers.py` directly exercises each of the three fixed code paths with targeted fixtures
- `test_action_parsing.py` confirms the pyparsing grammar rejects malformed input
- CI matrix (Ubuntu/Windows/macOS × Python 3.8–3.12) should now pass cleanly