### PR TITLE
Drop distutils for Python 3.12 compatibility (closes #58)

### DIFF
--- a/bionetgen/core/utils/utils.py
+++ b/bionetgen/core/utils/utils.py
@@ -1,7 +1,8 @@
-import os, subprocess
-from bionetgen.core.exc import BNGPerlError
-from distutils import spawn
+import os
+import shutil
+import subprocess
 
+from bionetgen.core.exc import BNGPerlError
 from bionetgen.core.utils.logging import BNGLogger
 
 
@@ -589,7 +590,7 @@ def find_BNG_path(BNGPATH=None):
             return hit
 
     # 3) On PATH
-    bng_on_path = spawn.find_executable("BNG2.pl")
+    bng_on_path = shutil.which("BNG2.pl")
     if bng_on_path:
         tried.append(bng_on_path)
         hit = _try_path(bng_on_path)
@@ -616,7 +617,7 @@ def test_perl(app=None, perl_path=None):
     logger.debug("Checking if perl is installed.", loc=f"{__file__} : test_perl()")
     # find path to perl binary
     if perl_path is None:
-        perl_path = spawn.find_executable("perl")
+        perl_path = shutil.which("perl")
     if perl_path is None:
         raise BNGPerlError
     # check if perl is actually working

--- a/bionetgen/simulator/csimulator.py
+++ b/bionetgen/simulator/csimulator.py
@@ -25,6 +25,7 @@ def _new_ccompiler():
         ) from exc
     return ccompiler.new_compiler()
 
+
 # This allows access to the CLIs config setup
 app = BioNetGen()
 app.setup()

--- a/bionetgen/simulator/csimulator.py
+++ b/bionetgen/simulator/csimulator.py
@@ -1,10 +1,29 @@
 import ctypes, os, tempfile, bionetgen
 import numpy as np
 
-from distutils import ccompiler
 from .bngsimulator import BNGSimulator
 from bionetgen.main import BioNetGen
 from bionetgen.core.exc import BNGCompileError
+
+
+def _new_ccompiler():
+    """Return a distutils ccompiler instance, sourced from setuptools.
+
+    distutils was removed from the stdlib in Python 3.12; setuptools vendors
+    the same API as ``setuptools._distutils``. Imported lazily so that
+    ``import bionetgen`` does not require setuptools at runtime — only
+    instantiating ``CSimulator`` does.
+    """
+    try:
+        from setuptools._distutils import ccompiler
+    except ImportError as exc:
+        raise BNGCompileError(
+            None,
+            "CSimulator requires the distutils ccompiler API, which was "
+            "removed from the stdlib in Python 3.12. Install setuptools "
+            "(pip install setuptools) to provide it.",
+        ) from exc
+    return ccompiler.new_compiler()
 
 # This allows access to the CLIs config setup
 app = BioNetGen()
@@ -164,7 +183,7 @@ class CSimulator(BNGSimulator):
         else:
             print(f"model format not recognized: {model_file}")
         # set compiler
-        self.compiler = ccompiler.new_compiler()
+        self.compiler = _new_ccompiler()
         self.compiler.add_include_dir(conf.get("cvode_include"))
         self.compiler.add_library_dir(conf.get("cvode_lib"))
         # compile shared library


### PR DESCRIPTION
## Summary

`distutils` was removed from the stdlib in Python 3.12 (and emits a `DeprecationWarning` before then). This PR replaces the two remaining usages with stdlib / setuptools equivalents:

- **`bionetgen/core/utils/utils.py`**: `distutils.spawn.find_executable` → `shutil.which`. Same arg, same return semantics (absolute path or `None`).
- **`bionetgen/simulator/csimulator.py`**: `distutils.ccompiler` → lazy `setuptools._distutils.ccompiler` via a small `_new_ccompiler()` helper. The import is deferred to `CSimulator.__init__`, so plain `import bionetgen` does not require `setuptools` at runtime — only instantiating `CSimulator` (the `cpy` simulator path) does, and that path already requires a local CVODE install. Missing `setuptools` raises a clear `BNGCompileError` with install guidance.

Closes #58.

## Note on #59 / #61

Both #59 and #61 are about `from pkg_resources import packaging` failing under newer setuptools / Python. That import was already replaced in `c392f2b` ("CI fixes") and is in `main` today (line 21 of `bionetgen/main.py`). The tickets are still open but the underlying bug is gone — they could be closed at the same time as this PR.

## Test plan

- [ ] CI passes on the supported Python versions
- [ ] `import bionetgen` works on Python 3.12 with no `distutils` available
- [ ] `bionetgen run -i ...` (CLI path that uses `find_BNG_path` → `shutil.which`) works
- [ ] `CSimulator(...)` raises a clear `BNGCompileError` on a system without setuptools, and works normally with setuptools installed