### PR TITLE
Accept `check_iso` flag on `generate_network` action

### DIFF
--- a/bionetgen/core/utils/utils.py
+++ b/bionetgen/core/utils/utils.py
@@ -104,6 +104,7 @@ class ActionList:
             "max_agg",
             "max_iter",
             "max_stoich",
+            "check_iso",
             "TextReaction",
             "TextSpecies",
         ]


### PR DESCRIPTION
## Summary

\`check_iso\` is a real BNG2.pl flag (\`Perl2/SpeciesList.pm\`, \`Perl2/RxnRule.pm\`) that controls canonical-isomorphism checking when adding species. The modelapi action allowlist in \`ActionList.arg_dict\` is missing it, so any model that uses \`generate_network({check_iso=>1, ...})\` fails at parse time with:

\`\`\`
Action argument check_iso not recognized for action generate_network!
\`\`\`

before BNG2.pl is ever invoked.

## Fix

One-line addition: \`"check_iso"\` joins the existing list of accepted args for \`generate_network\` in \`bionetgen/core/utils/utils.py\`.

## Test plan

- [ ] Existing CI passes
- [ ] Round-trip a model containing \`generate_network({check_iso=>1, max_stoich=>{...}})\` no longer raises \`Action argument check_iso not recognized\`