### PR TITLE
Allow bareword keys in nested action-arg hashes

### DIFF
--- a/bionetgen/core/utils/utils.py
+++ b/bionetgen/core/utils/utils.py
@@ -487,7 +487,10 @@ class ActionList:
         arg_type_list = "[" + pp.delimitedList((quote_word ^ arg_type_float)) + "]"
         arg_type_string = quote_word
         #
-        curly_arg_token = quote_word + "=>" + arg_type_int
+        # BNGL/Perl `=>` auto-quotes its left operand, so dict keys
+        # may be either bareword (max_stoich=>{R=>6}) or quoted
+        # (max_stoich=>{"R"=>6}). Accept both.
+        curly_arg_token = (base_name ^ quote_word) + "=>" + arg_type_int
         # TODO: handle 0 case
         arg_type_curly = "{" + pp.delimitedList(curly_arg_token) + "}"
         arg_types = (


### PR DESCRIPTION
## Summary

BNGL inherits Perl's \`=>\` fat-comma semantics, so action arguments like \`generate_network({overwrite=>1,max_stoich=>{R=>6}})\` are syntactically valid even though the inner hash key \`R\` is unquoted (the \`=>\` auto-quotes its left operand).

The pyparsing grammar in \`ActionList.define_parser()\` (\`bionetgen/core/utils/utils.py\`) requires \`quote_word\` for nested-curly keys, so any model that uses bareword keys — notably \`max_stoich=>{<molecule>=><N>}\` — fails at parse time before BNG2.pl is ever invoked.

## Fix

Accept either bareword or quoted keys inside nested hashes:

\`\`\`python
curly_arg_token = (base_name ^ quote_word) + "=>" + arg_type_int
\`\`\`

The existing dict-handling path in \`BNGParser._parse_action_line\` rebuilds the literal substring verbatim, so round-trip via \`Action.gen_string()\` is unchanged.

## Test plan

- [ ] Existing CI passes
- [ ] Round-trip a model with \`generate_network({max_stoich=>{R=>6}})\` parses cleanly
- [ ] Round-trip a model with \`generate_network({max_stoich=>{"R"=>6}})\` (quoted form) still parses cleanly