### PR TITLE
Don't collapse `\` continuations inside commented BNGL lines

### DIFF
--- a/bionetgen/modelapi/bngfile.py
+++ b/bionetgen/modelapi/bngfile.py
@@ -150,10 +150,20 @@ class BNGFile:
         with open(model_path, "r", encoding="UTF-8") as mf:
             # read and strip actions
             mstr = mf.read()
-            # TODO: Clean this up _a lot_
-            # this removes any new line escapes (\ \n) to continue
-            # to another line, so we can just remove the action lines
-            mstr = re.sub(r"\\\n", "", mstr)
+            # Collapse `\<newline>` line continuations before stripping
+            # action lines, so the action parser sees the same logical
+            # command boundaries as BNG.
+            #
+            # Only collapse `\` that appears before any `#` on its line.
+            # A continuation marker after the comment introducer is part
+            # of the comment body in BNG2.pl — collapsing it would glue
+            # the next physical line (often a real definition) into the
+            # comment, dropping it from the model. Repro: a commented-out
+            # `# foo()=if(t<42,0,\` immediately above a live
+            # `foo()=if(t<42,9.899,\` definition would silently lose the
+            # live function from the regenerated `.bngl` (and from any
+            # `.net` BNG2.pl generated downstream).
+            mstr = re.sub(r"^([^#\n]*)\\\n", r"\1", mstr, flags=re.MULTILINE)
             mlines = mstr.split("\n")
             stripped_lines = list(filter(lambda x: self._not_action(x), mlines))
             # remove spaces, actions don't allow them


### PR DESCRIPTION
## Summary

\`BNGFile.strip_actions\` folds trailing-backslash line continuations before the action parser sees them, but the regex doesn't currently respect comments. A commented-out

\`\`\`
# foo()=if(t<42,0,\
```

immediately above a live

\`\`\`
foo()=if(t<42,9.899,\
```

glues both into the comment, and the live definition silently disappears from the rendered \`.bngl\` (and from any \`.net\` BNG2.pl generates downstream).

## Fix

Anchor the regex to start-of-line and require no \`#\` between that and the trailing \`\\\` — comment lines keep their continuation markers as part of the comment body, which is what BNG2.pl itself does.

\`\`\`python
mstr = re.sub(r"^([^#\n]*)\\\n", r"\1", mstr, flags=re.MULTILINE)
```

## Test plan

- [ ] Existing CI passes
- [ ] A model with a commented-out \`\\\`-continuation immediately above a live function definition preserves the live definition through round-trip