### PR TITLE
Render multi-bond first partner as flat `!N!N`, not `!N![N]`

### DIFF
--- a/bionetgen/modelapi/xmlparsers.py
+++ b/bionetgen/modelapi/xmlparsers.py
@@ -114,7 +114,11 @@ class BondsXML:
                 if bond_partner_1 not in self.bonds_dict:
                     self.bonds_dict[bond_partner_1] = [ibond + 1]
                 else:
-                    self.bonds_dict[bond_partner_1].append([ibond + 1])
+                    # B13: must append the int, not a [int] list — the
+                    # rendered Component.__str__ emits ``f"!{bond}"`` per
+                    # entry, so a list ``[2]`` would render as ``![2]``,
+                    # which BNG2.pl reads as a compartment specifier.
+                    self.bonds_dict[bond_partner_1].append(ibond + 1)
                 if bond_partner_2 not in self.bonds_dict:
                     self.bonds_dict[bond_partner_2] = [ibond + 1]
                 else:


### PR DESCRIPTION
## Summary

\`BondsXML.resolve_xml\` has an off-by-one-character bug: when the SAME site is the first partner of two or more bonds (the \`hub(x!1!2)\` shape), the second-and-later bond IDs are appended to \`self.bonds_dict\` as a one-element LIST \`[ibond + 1]\` instead of as the int \`ibond + 1\`. The second partner's branch already appends the int correctly, so the bug only surfaces for sites that appear as \`bond_partner_1\` in multiple bonds.

\`Component.__str__\` then runs \`f"!{bond}"\` over the flat bonds list, which turns \`[2]\` into \`![2]\`. BNG2.pl reads \`![N]\` as a compartment specifier in pattern syntax and aborts with \`Invalid syntax at ![2]\` when it re-loads the regenerated BNGL.

## Fix

Append the int (parity with the second-partner branch).

## Test plan

- [ ] Existing CI passes
- [ ] A model with a site participating in 2+ bonds (\`hub(x!1!2)\`) round-trips through XML and regenerates a BNG2.pl-loadable \`.bngl\`