### PR TITLE
Fix Pattern/Molecule equality and mutable default arguments

### DIFF
--- a/bionetgen/modelapi/pattern.py
+++ b/bionetgen/modelapi/pattern.py
@@ -58,9 +58,14 @@ class Pattern:
     """
 
     def __init__(
-        self, molecules=[], bonds=None, compartment=None, label=None, canonicalize=False
+        self,
+        molecules=None,
+        bonds=None,
+        compartment=None,
+        label=None,
+        canonicalize=False,
     ):
-        self.molecules = molecules
+        self.molecules = list(molecules) if molecules is not None else []
         self._bonds = bonds
         self.compartment = compartment
         self.label = label
@@ -287,6 +292,12 @@ class Pattern:
                             other.canonical_label is not None
                         ):
                             return self.canonical_label == other.canonical_label
+                        if len(self.molecules) != len(other.molecules):
+                            logger.debug(
+                                f"molecule count differs: {len(self.molecules)} vs {len(other.molecules)}",
+                                loc=loc,
+                            )
+                            return False
                         # now we can check contents
                         for molecule in self:
                             if molecule not in other.molecules:
@@ -374,8 +385,6 @@ class Pattern:
     def __iter__(self):
         return self.molecules.__iter__()
 
-    # TODO: Implement __contains__
-
 
 class Molecule:
     """
@@ -402,9 +411,9 @@ class Molecule:
         (for molecule types) "states"
     """
 
-    def __init__(self, name="0", components=[], compartment=None, label=None):
+    def __init__(self, name="0", components=None, compartment=None, label=None):
         self._name = name
-        self._components = components
+        self._components = list(components) if components is not None else []
         self._compartment = compartment
         self._label = label
         self.canonical_order = None
@@ -435,6 +444,12 @@ class Molecule:
                     # we can check canonical labels
                     if self.canonical_label != other.canonical_label:
                         return False
+                if len(self.components) != len(other.components):
+                    logger.debug(
+                        f"component count differs: {len(self.components)} vs {len(other.components)}",
+                        loc=loc,
+                    )
+                    return False
                 # check components now
                 for component in self:
                     if component not in other.components:
@@ -547,14 +562,14 @@ class Molecule:
         # print("Warning: Logical checks are not complete")
         self._label = value
 
-    def _add_component(self, name, state=None, states=[]):
+    def _add_component(self, name, state=None, states=None):
         comp_obj = Component()
         comp_obj.name = name
         comp_obj.state = state
-        comp_obj.states = states
+        comp_obj.states = list(states) if states is not None else []
         self.components.append(comp_obj)
 
-    def add_component(self, name, state=None, states=[]):
+    def add_component(self, name, state=None, states=None):
         # TODO: Add built-in logic here
         # print("Warning: Logical checks are not complete")
         self._add_component(name, state, states)


### PR DESCRIPTION
## Summary

Two related fixes in \`bionetgen/modelapi/pattern.py\`:

### Equality is one-way
\`Pattern.__eq__\` and \`Molecule.__eq__\` only check subset membership of molecules / components, so a pattern is considered equal to a strict superset (a one-molecule pattern compares equal to a two-molecule pattern that happens to contain it). Add explicit length checks so the directions are symmetric.

### Mutable default args
\`Pattern.__init__\`, \`Molecule.__init__\`, \`Molecule._add_component\`, and \`Molecule.add_component\` use mutable list literals as default arguments (\`molecules=[]\`, \`components=[]\`, \`states=[]\`). The classic Python pitfall: every call without those args reuses the SAME list, so \`add_component\` calls on different molecules can silently leak components into each other.

Replace the literals with the standard \`None\` plumbing so each instance gets its own list.

Also drops a stale \`# TODO: Implement __contains__\` comment — \`__contains__\` has been implemented for some time.

## Test plan

- [ ] Existing CI passes
- [ ] Construct two \`Pattern\`s with different molecule counts; \`==\` returns False both directions
- [ ] Construct two \`Molecule\`s, call \`add_component\` on one, verify the other doesn't see the new component