### PR TITLE
Capture stdout/stderr in `run_command`'s timeout path so BNG2.pl errors reach callers

### DIFF
--- a/bionetgen/core/utils/utils.py
+++ b/bionetgen/core/utils/utils.py
@@ -655,20 +655,18 @@ def run_command(command, suppress=True, timeout=None, cwd=None):
     be killed.
     """
     if timeout is not None:
-        if suppress:
-            # I am unsure how to do both timeout and the live polling of stdo
-            rc = subprocess.run(
-                command,
-                timeout=timeout,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                cwd=cwd,
-            )
-            return rc.returncode, rc
-        else:
-            # I am unsure how to do both timeout and the live polling of stdo
-            rc = subprocess.run(command, timeout=timeout, capture_output=True, cwd=cwd)
-            return rc.returncode, rc
+        # Always capture stdout/stderr — this lets callers (notably BNGCLI)
+        # surface BNG2.pl's error tail in BNGRunError when the command
+        # fails. With timeout set, subprocess.run buffers all output
+        # anyway, so suppress=True vs False makes no behavioral difference
+        # for the user during the run.
+        rc = subprocess.run(
+            command,
+            timeout=timeout,
+            capture_output=True,
+            cwd=cwd,
+        )
+        return rc.returncode, rc
     else:
         if suppress:
             process = subprocess.Popen(


### PR DESCRIPTION
## Summary

\`run_command(suppress=True, timeout=set)\` in \`bionetgen/core/utils/utils.py\` redirects stdout/stderr to \`DEVNULL\`, so when \`BNGCLI\` raises \`BNGRunError\` on a failing BNG2.pl invocation, the actual diagnostic message (e.g. \`Missing end parentheses ... at and(...)\`) never reaches the user.

## Fix

Always capture stdout/stderr. With a timeout set, \`subprocess.run\` buffers all output anyway, so the \`suppress\` distinction is already a no-op for the user during the run — what it does do is discard the bytes needed to build a useful error message after the fact.

After this, the \`_run.log\` for a failing BNG2.pl call shows the real ABORT message, which makes round-trip / regenerated-BNGL bugs trivial to localize.

## Test plan

- [ ] Existing CI passes
- [ ] A failing BNG2.pl invocation surfaces its stdout/stderr tail through whatever caller wraps \`run_command\` (e.g. \`BNGCLI\`'s \`BNGRunError\` message)