### PR TITLE
Anchor BNGL action-name detection to start-of-line

### DIFF
--- a/bionetgen/modelapi/bngfile.py
+++ b/bionetgen/modelapi/bngfile.py
@@ -192,8 +192,14 @@ class BNGFile:
         return stripped_model
 
     def _not_action(self, line) -> bool:
+        # Anchor the match to the start of the (left-stripped) line so that
+        # user identifiers containing an action name as a substring — most
+        # commonly ``conversion()`` (the substring ``version(`` matches the
+        # ``version`` action) inside a ``begin functions`` block — aren't
+        # misclassified and pulled out as actions.
+        stripped = line.lstrip()
         for action in self._action_list:
-            if action in line:
+            if stripped.startswith(action):
                 return False
         return True
 


### PR DESCRIPTION
## Summary

\`BNGFile._not_action\` does an unanchored substring search of action names against each line, so any line that *contains* an action name as a substring gets pulled out of its block and pushed into the action list. The repeated repro is \`conversion()=...\` inside a \`begin functions\` block — the substring \`version(\` matches the \`version\` action prefix and the line gets misclassified.

Same pitfall exists for \`bifurcate\` (any identifier ending in \`...ifurcate\`), \`simulate_ssa\` / \`simulate_nf\` / \`simulate_pla\` / \`simulate_ode\` (any expression that mentions one of these names), and \`readFile\` / \`writeFile\` (any path or function with the substring).

## Fix

Anchor the match to the start of the left-stripped line so user identifiers that look like an action name in the middle of an expression are no longer misclassified. Indentation is still allowed before the action name to match existing behavior.

## Test plan

- [ ] Existing CI passes
- [ ] A model containing \`conversion()=...\` inside \`begin functions\` parses without losing the function