### PR TITLE
Accept trailing whitespace between `\` and newline in line continuations

### DIFF
--- a/bionetgen/modelapi/bngfile.py
+++ b/bionetgen/modelapi/bngfile.py
@@ -150,10 +150,11 @@ class BNGFile:
         with open(model_path, "r", encoding="UTF-8") as mf:
             # read and strip actions
             mstr = mf.read()
-            # TODO: Clean this up _a lot_
-            # this removes any new line escapes (\ \n) to continue
-            # to another line, so we can just remove the action lines
-            mstr = re.sub(r"\\\n", "", mstr)
+            # Collapse `\<newline>` line continuations before stripping action
+            # lines. BNG2.pl also tolerates trailing whitespace between the
+            # `\` and the newline (e.g. `method=>"ode",\<space><newline>` is
+            # valid BNGL); accept the same shape here.
+            mstr = re.sub(r"\\[ \t]*\n", "", mstr)
             mlines = mstr.split("\n")
             stripped_lines = list(filter(lambda x: self._not_action(x), mlines))
             # remove spaces, actions don't allow them


### PR DESCRIPTION
## Summary

\`BNGFile.strip_actions\` collapses \`\\<newline>\` continuations before stripping action lines, but the regex \`r"\\\n"\` rejects shapes like:

\`\`\`
method=>"ode",\<space><newline>
\`\`\`

which appear in real-world BNGL. BNG2.pl tolerates trailing whitespace between the \`\\\` and the newline; the modelapi parser should too.

## Fix

Loosen the regex to \`r"\\[ \t]*\n"\`.

## Note on conflict with #79

This PR and #79 (\"Don't collapse \`\\\` continuations inside commented BNGL lines\") both modify the same line. Logically the two fixes compose — the combined regex would be \`r"^([^#\n]*)\\[ \t]*\n"\` with MULTILINE — but I've kept them as separate PRs per the audit's split guidance. Whichever lands first, the other can rebase trivially.

## Test plan

- [ ] Existing CI passes
- [ ] A model with \`...,\\<space><newline>...\` no longer drops the continuation line on the floor