### PR TITLE
Lossless BNG-XML \xe2\x86\x92 BNGL round-trip for tfun, rule modifiers, selectors

### DIFF
--- a/bionetgen/modelapi/rulemod.py
+++ b/bionetgen/modelapi/rulemod.py
@@ -1,21 +1,37 @@
 class RuleMod:
     """
     Rule modifiers class for storage and printing.
+
+    A single rule may carry several modifiers — e.g. `DeleteMolecules`
+    together with `include_reactants(...)` / `exclude_products(...)`.
+    `self.modifiers` stores the BNGL serialization of each in insertion
+    order; `self.type` continues to track the single legacy modifier
+    name for backwards compatibility.
     """
 
-    def __init__(self, mod_type=None) -> None:
+    def __init__(self, mod_type=None, modifiers=None) -> None:
         # valid mod types
         self.valid_mod_names = ["DeleteMolecules", "MoveConnected", "TotalRate"]
+        self.modifiers: list[str] = []
         self.type = mod_type
+        if modifiers is not None:
+            for modifier in modifiers:
+                self.add_modifier(modifier)
 
     def __str__(self) -> str:
+        if len(self.modifiers) > 0:
+            return " ".join(self.modifiers)
         if self.type is None:
             return ""
-        else:
-            return self.type
+        return self.type
 
     def __repr__(self) -> str:
         return f"Rule modifier of type {self.type}"
+
+    def add_modifier(self, modifier) -> None:
+        text = str(modifier).strip()
+        if text and text not in self.modifiers:
+            self.modifiers.append(text)
 
     @property
     def type(self):

--- a/bionetgen/modelapi/xmlparsers.py
+++ b/bionetgen/modelapi/xmlparsers.py
@@ -1,3 +1,5 @@
+import re
+
 from .blocks import ParameterBlock, CompartmentBlock, ObservableBlock
 from .blocks import SpeciesBlock, MoleculeTypeBlock
 from .blocks import FunctionBlock, RuleBlock
@@ -494,7 +496,7 @@ class FunctionBlockXML(XMLObj):
             for f in xml:
                 # add content to line
                 fname = f["@id"]
-                expr = f["Expression"]
+                expr = self._resolve_expression(f)
                 args = []
                 if "ListOfArguments" in f:
                     args = self.get_arguments(f["ListOfArguments"]["Argument"])
@@ -502,7 +504,7 @@ class FunctionBlockXML(XMLObj):
                 block.add_function(fname, expr, args=args)
         else:
             fname = xml["@id"]
-            expr = xml["Expression"]
+            expr = self._resolve_expression(xml)
             args = []
             if "ListOfArguments" in xml:
                 args = self.get_arguments(xml["ListOfArguments"]["Argument"])
@@ -510,6 +512,40 @@ class FunctionBlockXML(XMLObj):
             block.add_function(fname, expr, args=args)
 
         return block
+
+    def _resolve_expression(self, f) -> str:
+        """Return the BNGL expression body for a Function XML element.
+
+        Most functions serialize their body verbatim into ``<Expression>``,
+        but BNG2.pl rewrites ``tfun(...)`` calls (both the inline-array form
+        and the file-based ``TFUN(arg, "file")`` form) as the placeholder
+        ``__TFUN_VAL__`` and stashes the real arguments in attributes on
+        the ``<Function>`` element. Round-tripping the placeholder back
+        into BNGL is invalid — BNG2.pl can't re-parse it. Reconstruct the
+        call from the attributes when present.
+        """
+        raw = str(f.get("Expression", ""))
+        if f.get("@type") != "TFUN":
+            return raw
+
+        ctr = str(f.get("@ctrName", ""))
+        if "@xData" in f:
+            xs = str(f.get("@xData", ""))
+            ys = str(f.get("@yData", ""))
+            method = str(f.get("@method", "linear"))
+            body = f"tfun([{xs}],[{ys}],{ctr}"
+            if method and method != "linear":
+                body += f',method=>"{method}"'
+            body += ")"
+        elif "@file" in f:
+            body = f'TFUN({ctr},"{str(f.get("@file", ""))}")'
+        else:
+            body = raw
+
+        for placeholder in ("__TFUN__VAL__", "__TFUN_VAL__"):
+            if placeholder in raw:
+                return raw.replace(placeholder, body).strip()
+        return body.strip()
 
     def get_arguments(self, xml) -> list:
         args = []
@@ -692,11 +728,11 @@ class RuleBlockXML(XMLObj):
         return ops
 
     def get_rule_mod(self, xml):
-        # TODO: create working rule mods class
         rule_mod = RuleMod()
-        list_ops = xml["ListOfOperations"]
+        list_ops = xml.get("ListOfOperations")
+        had_explicit_ops = list_ops is not None
         if list_ops is None:
-            return None
+            list_ops = {}
         # determine which rule mod is being used, if any
         if "Delete" in list_ops:
             del_op = list_ops["Delete"]
@@ -707,6 +743,7 @@ class RuleBlockXML(XMLObj):
             # it does not apply to the whole rule
             if all(val == "1" for val in dmvals):
                 rule_mod.type = "DeleteMolecules"
+                rule_mod.add_modifier("DeleteMolecules")
                 # JRF: I don't believe the id of the specific op rule_mod is currently used
                 # rule_mod.id = op["@id"]
         elif "ChangeCompartment" in list_ops:
@@ -717,6 +754,7 @@ class RuleBlockXML(XMLObj):
                 # check if modifier was called or automatic
                 if mod_call == "1":
                     rule_mod.type = "MoveConnected"
+                    rule_mod.add_modifier("MoveConnected")
                     rule_mod.id = move_op["@id"]
                     rule_mod.source = move_op["@source"]
                     rule_mod.destination = move_op["@destination"]
@@ -731,6 +769,7 @@ class RuleBlockXML(XMLObj):
                 for mo in move_op:
                     if mo["@moveConnected"] == "1":
                         rule_mod.type = "MoveConnected"
+                        rule_mod.add_modifier("MoveConnected")
                         rule_mod.id.append(mo["@id"])
                         rule_mod.source.append(mo["@source"])
                         rule_mod.destination.append(mo["@destination"])
@@ -742,22 +781,81 @@ class RuleBlockXML(XMLObj):
             rate_type = ratelaw["@type"]
             if rate_type == "Function" and str(ratelaw.get("@totalrate", "0")) == "1":
                 rule_mod.type = "TotalRate"
+                rule_mod.add_modifier("TotalRate")
                 rule_mod.id = ratelaw["@id"]
                 rule_mod.rate_type = ratelaw["@type"]
                 rule_mod.name = ratelaw["@name"]
                 rule_mod.call = ratelaw.get("@totalrate", "0")
 
-        # TODO: add support for include/exclude reactants/products
+        # Include / exclude reactants and products are also rule modifiers in BNGL.
+        # BNG2.pl emits them as ListOfInclude{Reactants,Products} /
+        # ListOfExclude{Reactants,Products} children on the rule, each carrying
+        # a pattern-index suffix (_RP<n> / _PP<n>) on the selector id and one
+        # or more Pattern entries. Mirror those back as
+        #   include_reactants(<n>,<pattern>)
+        #   exclude_products(<n>,<pattern>)
+        # etc., so the rule round-trips through BNG2.pl.
+        for key, value in xml.items():
+            if key not in (
+                "ListOfIncludeReactants",
+                "ListOfIncludeProducts",
+                "ListOfExcludeReactants",
+                "ListOfExcludeProducts",
+            ):
+                continue
+            selectors = value if isinstance(value, list) else [value]
+            for selector in selectors:
+                call = self._build_selector_modifier(key, selector)
+                if call is not None:
+                    rule_mod.add_modifier(call)
+
         if (
-            "ListOfIncludeReactants" in xml
-            or "ListOfIncludeProducts" in xml
-            or "ListOfExcludeReactants" in xml
-            or "ListOfExcludeProducts" in xml
+            rule_mod.type is None
+            and len(rule_mod.modifiers) == 0
+            and not had_explicit_ops
         ):
-            print(
-                "WARNING: Include/Exclude Reactants/Products not currently supported as rule modifiers"
-            )
+            return None
         return rule_mod
+
+    def _build_selector_modifier(self, key, selector_xml):
+        call_names = {
+            "ListOfIncludeReactants": "include_reactants",
+            "ListOfExcludeReactants": "exclude_reactants",
+            "ListOfIncludeProducts": "include_products",
+            "ListOfExcludeProducts": "exclude_products",
+        }
+        call_name = call_names.get(key)
+        if call_name is None:
+            return None
+        selector_id = str(selector_xml.get("@id", ""))
+        match = re.search(r"_(?:RP|PP)(\d+)$", selector_id)
+        if match is None:
+            return None
+        pattern_xml = selector_xml.get("Pattern")
+        if pattern_xml is None:
+            return None
+        patterns = pattern_xml if isinstance(pattern_xml, list) else [pattern_xml]
+        pattern_parts = [self._format_selector_pattern(pattern) for pattern in patterns]
+        pattern_str = " + ".join(pattern_parts)
+        return f"{call_name}({match.group(1)},{pattern_str})"
+
+    def _format_selector_pattern(self, pattern_xml):
+        pattern = PatternXML(pattern_xml).parsed_obj
+        if len(pattern.molecules) == 1:
+            molecule = pattern.molecules[0]
+            if (
+                molecule.name != "0"
+                and len(molecule.components) == 0
+                and molecule.compartment is None
+                and molecule.label is None
+                and pattern.compartment is None
+                and not pattern.fixed
+                and not pattern.MatchOnce
+                and pattern.relation is None
+                and pattern.quantity is None
+            ):
+                return molecule.name
+        return str(pattern)
 
 
 class EnergyPatternBlockXML(XMLObj):


### PR DESCRIPTION
## Summary

Three related fidelity fixes when reading BNG2.pl-emitted BNG-XML and re-emitting BNGL. Each fixes a specific shape that the parser currently drops, mangles, or warns about and ignores.

### 1. \`tfun\` placeholder reconstruction

BNG2.pl serializes \`tfun(...)\` calls — both the inline-array form \`tfun([xs],[ys],ctr)\` and the file-based \`TFUN(ctr,"file")\` form — by replacing the function body with a \`__TFUN_VAL__\` / \`__TFUN__VAL__\` placeholder and stashing the real arguments on attributes of the \`<Function>\` element (\`@ctrName\`, \`@xData\`, \`@yData\`, \`@method\`, \`@file\`).

\`FunctionBlockXML.parse_xml\` was reading the placeholder verbatim into the regenerated BNGL, which BNG2.pl can't re-parse. New \`_resolve_expression\` helper reconstructs the call from the attributes.

### 2. \`RuleMod\` supports multiple modifiers per rule

A single rule can legitimately carry, say, \`DeleteMolecules\` together with \`include_reactants(...)\`. \`RuleMod.modifiers: list[str]\` stores the BNGL serialization of each modifier in insertion order. \`__str__\` prefers the list when non-empty, falling back to the single \`self.type\` so existing callers that read \`rule_mod.type\` keep working.

### 3. \`include\` / \`exclude\` reactants / products as rule modifiers

These are now emitted as rule modifiers instead of being dropped with a stderr warning. BNG2.pl serializes them as \`ListOfInclude{Reactants,Products}\` / \`ListOfExclude{Reactants,Products}\` children on the rule, each carrying a pattern-index suffix (\`_RP<n>\` / \`_PP<n>\`) on the selector id and one or more \`<Pattern>\` entries. New helpers \`_build_selector_modifier\` and \`_format_selector_pattern\` mirror those back as e.g. \`include_reactants(1, MyMol)\`.

The \`get_rule_mod\` body is also tightened: it now tolerates rules that have no \`ListOfOperations\` at all (previously \`KeyError\`) and returns \`None\` only when there's genuinely no modifier to report, instead of dropping a real one when \`ListOfOperations\` happens to be missing.

## Note on conflict with #76

This PR and #76 both modify the import block of \`xmlparsers.py\` to add \`import re\`, and both modify \`FunctionBlockXML.parse_xml\` to wrap the \`Expression\` read. The two rewrites compose — \`_decode_xml_boolean_ops(_resolve_expression(...))\` is the combined call — but I've kept them as separate PRs since the audit's table 0.4 split them. Whichever lands first, the other rebases trivially.

## Test plan

- [ ] Existing CI passes
- [ ] A model using \`tfun(...)\` round-trips through XML and BNG2.pl re-parses the regenerated BNGL
- [ ] A rule using \`include_reactants(...)\` round-trips through XML
- [ ] A rule combining \`DeleteMolecules\` with \`include_reactants(...)\` emits both modifiers