### PR TITLE
Add cached app/config accessors in bionetgen.main

### DIFF
--- a/bionetgen/main.py
+++ b/bionetgen/main.py
@@ -1,3 +1,5 @@
+import functools
+
 import cement
 import bionetgen as bng
 from cement.core.exc import CaughtSignal
@@ -623,6 +625,24 @@ class BioNetGenTest(cement.TestApp, BioNetGen):
 
     class Meta:
         label = "bionetgen"
+
+
+@functools.cache
+def get_default_app():
+    """Return a configured BioNetGen cement app, initialized once per process."""
+    app = BioNetGen()
+    app.setup()
+    return app
+
+
+def get_conf():
+    """Return the bionetgen config section from the shared app."""
+    return get_default_app().config["bionetgen"]
+
+
+def get_default_bng_path():
+    """Return the default BNG2.pl path from config."""
+    return get_conf()["bngpath"]
 
 
 def main():

--- a/bionetgen/main.py
+++ b/bionetgen/main.py
@@ -627,7 +627,7 @@ class BioNetGenTest(cement.TestApp, BioNetGen):
         label = "bionetgen"
 
 
-@functools.cache
+@functools.lru_cache(maxsize=None)
 def get_default_app():
     """Return a configured BioNetGen cement app, initialized once per process."""
     app = BioNetGen()

--- a/tests/test_main_accessors.py
+++ b/tests/test_main_accessors.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock, patch
+
+
+def test_get_default_app_is_cached():
+    from bionetgen import main as main_module
+
+    main_module.get_default_app.cache_clear()
+    fake_app = MagicMock()
+
+    with patch.object(main_module, "BioNetGen", return_value=fake_app) as mock_app_cls:
+        app1 = main_module.get_default_app()
+        app2 = main_module.get_default_app()
+
+    assert app1 is fake_app
+    assert app2 is fake_app
+    mock_app_cls.assert_called_once_with()
+    fake_app.setup.assert_called_once_with()
+    main_module.get_default_app.cache_clear()
+
+
+def test_get_conf_uses_cached_default_app():
+    from bionetgen import main as main_module
+
+    main_module.get_default_app.cache_clear()
+    fake_app = MagicMock()
+    fake_app.config = {"bionetgen": {"bngpath": "/fake/BNG2.pl", "other": "value"}}
+
+    with patch.object(main_module, "BioNetGen", return_value=fake_app) as mock_app_cls:
+        conf1 = main_module.get_conf()
+        conf2 = main_module.get_conf()
+
+    assert conf1 == {"bngpath": "/fake/BNG2.pl", "other": "value"}
+    assert conf2 is conf1
+    mock_app_cls.assert_called_once_with()
+    fake_app.setup.assert_called_once_with()
+    main_module.get_default_app.cache_clear()
+
+
+def test_get_default_bng_path_reads_bngpath_from_config():
+    from bionetgen import main as main_module
+
+    with patch.object(
+        main_module, "get_conf", return_value={"bngpath": "/tmp/BNG2.pl"}
+    ):
+        assert main_module.get_default_bng_path() == "/tmp/BNG2.pl"


### PR DESCRIPTION
## Summary

- Add cached app and config accessors in bionetgen.main.
- Rename the exported accessor to get_default_app and add focused tests for caching and default bngpath lookup.
- Keep this PR limited to the accessor lane and leave deferred app setup changes for later work.

## Testing

- uv run python -m pytest -q tests/test_main_accessors.py tests/test_bionetgen.py -k 'bionetgen_help or test_main_accessors'
- uvx black --check bionetgen/main.py tests/test_main_accessors.py