### PR TITLE
Unify block deletion and invalid-action errors

### DIFF
--- a/bionetgen/modelapi/blocks.py
+++ b/bionetgen/modelapi/blocks.py
@@ -87,10 +87,7 @@ class ModelBlock:
         self.items[key] = value
 
     def __delitem__(self, key) -> None:
-        if key in self.items:
-            self.items.pop(key)
-        else:
-            print("Item {} not found".format(key))
+        self.items.pop(key)
 
     def __iter__(self):
         return self.items.keys().__iter__()
@@ -608,11 +605,7 @@ class ActionBlock(ModelBlock):
         self.items[key] = value
 
     def __delitem__(self, key) -> None:
-        try:
-            return self.items.pop(key)
-        # TODO: more specific except statements
-        except:
-            print("Item {} not found".format(key))
+        return self.items.pop(key)
 
     def __iter__(self):
         return range(len(self.items)).__iter__()
@@ -625,13 +618,8 @@ class ActionBlock(ModelBlock):
         adds action, needs type as string and args as list of tuples
         (which preserve order) of (argument, value) pairs
         """
-        if action_type in self._action_list:
-            a = Action(action_type=action_type, action_args=action_args)
-            self.add_item((action_type, a))
-        else:
-            print(
-                "Action type {} is not recognized as a BNGL action".format(action_type)
-            )
+        a = Action(action_type=action_type, action_args=action_args)
+        self.add_item((action_type, a))
 
     def clear_actions(self) -> None:
         self.items.clear()

--- a/bionetgen/network/blocks.py
+++ b/bionetgen/network/blocks.py
@@ -69,10 +69,7 @@ class NetworkBlock:
         self.items[key] = value
 
     def __delitem__(self, key) -> None:
-        if key in self.items:
-            self.items.pop(key)
-        else:
-            print("Item {} not found".format(key))
+        self.items.pop(key)
 
     def __iter__(self):
         return self.items.keys().__iter__()

--- a/tests/test_block_error_contracts.py
+++ b/tests/test_block_error_contracts.py
@@ -1,0 +1,39 @@
+"""Focused tests for block deletion and invalid-action error contracts."""
+
+import pytest
+
+from bionetgen.core.exc import BNGParseError
+from bionetgen.modelapi.blocks import ActionBlock, ModelBlock
+from bionetgen.network.blocks import NetworkBlock
+
+
+def test_model_block_delitem_missing_raises_keyerror():
+    block = ModelBlock()
+
+    with pytest.raises(KeyError, match="missing"):
+        del block["missing"]
+
+
+def test_network_block_delitem_missing_raises_keyerror():
+    block = NetworkBlock()
+
+    with pytest.raises(KeyError, match="missing"):
+        del block["missing"]
+
+
+def test_action_block_delitem_missing_raises_indexerror():
+    block = ActionBlock()
+
+    with pytest.raises(IndexError):
+        del block[99]
+
+
+def test_action_block_add_action_invalid_type_raises_parse_error():
+    block = ActionBlock()
+
+    with pytest.raises(
+        BNGParseError, match="Action type not_a_real_action not recognized!"
+    ):
+        block.add_action("not_a_real_action", {})
+
+    assert len(block.items) == 0


### PR DESCRIPTION
## Summary
- make missing block-item deletion raise the underlying key/index error instead of printing and continuing
- let invalid action types fail through the centralized action validation path instead of printing and returning
- add focused upstream-safe contract tests for the deletion and invalid-action paths

## Testing
- `uv run pytest tests/test_block_error_contracts.py -q`
- `uv run pytest tests/test_bionetgen.py::test_action_loading -q`
- `uvx black --check bionetgen/modelapi/blocks.py bionetgen/network/blocks.py tests/test_block_error_contracts.py`