### PR TITLE
Support python -m bionetgen

### DIFF
--- a/bionetgen/__main__.py
+++ b/bionetgen/__main__.py
@@ -2,6 +2,5 @@
 
 from .main import main
 
-
 if __name__ == "__main__":
     main()

--- a/bionetgen/__main__.py
+++ b/bionetgen/__main__.py
@@ -1,0 +1,7 @@
+"""Module entry point for ``python -m bionetgen``."""
+
+from .main import main
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_module_entrypoint.py
+++ b/tests/test_module_entrypoint.py
@@ -2,7 +2,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 

--- a/tests/test_module_entrypoint.py
+++ b/tests/test_module_entrypoint.py
@@ -1,0 +1,30 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_module(*args):
+    return subprocess.run(
+        [sys.executable, "-m", "bionetgen", *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_python_m_bionetgen_help():
+    result = _run_module("--help")
+
+    assert result.returncode == 0
+    assert "usage:" in (result.stdout + result.stderr).lower()
+
+
+def test_python_m_bionetgen_require_help():
+    result = _run_module("-req", "0.5.0", "--help")
+
+    assert result.returncode == 0
+    assert "usage:" in (result.stdout + result.stderr).lower()


### PR DESCRIPTION
## Summary
- add a package module entry point so `python -m bionetgen` invokes the existing CLI
- add regression coverage for module help and require/help invocation

## Tests
- `.venv/bin/python -m pytest tests/test_module_entrypoint.py`
